### PR TITLE
Fix message type handling and tool insertion bug

### DIFF
--- a/agentsoup.py
+++ b/agentsoup.py
@@ -130,7 +130,7 @@ class AgentSystemPrompt(SystemMessage):
         if len(tools) > 0 and "{tools}" not in prompt:
             raise ValueError("Prompt must contain {tools} if tools are provided")
 
-        super().__init__([Text(prompt.format(tools=tools))])
+        super().__init__([Text(prompt.format(tools=self._format_tools(tools)))])
     def _format_tools(self, tools: list[Function]):
         text = "```\n"
         for tool in tools:
@@ -182,9 +182,9 @@ def llm(model="gpt-4o-mini", **llm_kwargs):
             function_result = f(*args, **kwargs)
             if type(function_result) == str:
                 messages = [UserMessageText(function_result)]
-            elif type(function_result) == Message:
+            elif isinstance(function_result, Message):
                 messages = [function_result]
-            elif type(function_result) == list:
+            elif isinstance(function_result, list):
                 messages = function_result
             else:
                 raise ValueError(f"Unsupported return type: {type(function_result)}")


### PR DESCRIPTION
## Summary
- ensure subclasses of `Message` are handled correctly in `llm` decorator
- insert formatted tool definitions in `AgentSystemPrompt`

## Testing
- `python3 -m py_compile agentsoup.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b27cdac483288eae93e1224ae9ad